### PR TITLE
Use testing/quick for fuzzing, and add more fuzz

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,58 +1,107 @@
 package collapsewhitespace
 
 import (
-	"crypto/rand"
-	"fmt"
+	"math/rand"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
+	"testing/quick"
+	"time"
 )
 
-func fuzzInput() string {
-	b := make([]byte, 1024)
-	n, err := rand.Read(b)
-	if err != nil {
-		panic(fmt.Errorf("fuzzInput: rand.Read: %v", err))
+const fuzzWhitespace = " \t\n\v\f\r\u0085\u00A0"
+
+type spaceyString string
+
+func (s spaceyString) Generate(r *rand.Rand, size int) reflect.Value {
+	bytes := make([]byte, size)
+
+	// between 0 and size whitespace
+	whitespaceCount := r.Intn(size + 1)
+
+	// insert random whitespace
+	for i := 0; i < whitespaceCount; i++ {
+		bytes[i] = fuzzWhitespace[r.Intn(len(fuzzWhitespace))]
 	}
-	if n != len(b) {
-		panic(fmt.Errorf("fuzzInput: rand.Read: got %d bytes, want %d bytes", n, len(b)))
+
+	// fill remaining with random bytes
+	r.Read(bytes[whitespaceCount:])
+
+	// shuffle the bytes
+	perm := rand.Perm(len(bytes))
+	for i, j := range perm {
+		bytes[j], bytes[i] = bytes[i], bytes[j]
 	}
-	return string(b)
+
+	return reflect.ValueOf(spaceyString(bytes))
 }
 
-func fuzzInputs() []string {
-	inputs := [1024]string{}
-	for i := 0; i < len(inputs); i++ {
-		inputs[i] = fuzzInput()
+func checkString(t *testing.T, check func(input, output string) bool) {
+	t.Helper()
+
+	f := func(s spaceyString) bool {
+		return check(string(s), String(string(s)))
 	}
-	return inputs[:]
+
+	seed := time.Now().UnixNano()
+	t.Logf("Seed: %d", seed)
+
+	c := &quick.Config{
+		Rand: rand.New(rand.NewSource(seed)),
+	}
+
+	if err := quick.Check(f, c); err != nil {
+		if checkErr, ok := err.(*quick.CheckError); ok {
+			input := string(checkErr.In[0].(spaceyString))
+			t.Error(err)
+			t.Errorf("Input: %x", input)
+			t.Errorf("Output: %x", String(input))
+		} else {
+			t.Fatal(err)
+		}
+	}
 }
 
 func TestCompactFuzz_NoRepeatingWhitespace(t *testing.T) {
-	re := regexp.MustCompile(`\s{2,}`)
-	for _, input := range fuzzInputs() {
-		t.Run(input, func(t *testing.T) {
-			output := String(input)
-			if re.MatchString(output) {
-				t.Errorf("%q => %q has sequential whitespace", input, output)
-				return
-			}
-		})
+	re := regexp.MustCompile("[" + fuzzWhitespace + "]{2,}")
+
+	f := func(input, output string) bool {
+		hasRepeatingWhitespace := re.MatchString(output)
+		return !hasRepeatingWhitespace
 	}
+
+	checkString(t, f)
 }
 
 func TestCompactFuzz_ContainsOriginalNonWhitespaceCharacters(t *testing.T) {
-	re := regexp.MustCompile("[\t\n\v\f\r \u0085\u00a0]+")
-	for _, input := range fuzzInputs() {
-		t.Run(input, func(t *testing.T) {
-			words := re.Split(input, -1)
-			output := String(input)
-			for _, word := range words {
-				if !strings.Contains(output, word) {
-					t.Errorf("%#x => %#x is missing word(s) that should have remained: %#x", []byte(input), []byte(output), []byte(word))
-					return
-				}
+	re := regexp.MustCompile("[" + fuzzWhitespace + "]+")
+
+	f := func(input, output string) bool {
+		words := re.Split(input, -1)
+		for _, word := range words {
+			if !strings.Contains(output, word) {
+				return false
 			}
-		})
+		}
+		return true
 	}
+
+	checkString(t, f)
+}
+
+func TestCompactFuzz_OutputSmallerOrEqualLengthThanInput(t *testing.T) {
+	f := func(input, output string) bool {
+		return len(output) <= len(input)
+	}
+
+	checkString(t, f)
+}
+
+func TestCompactFuzz_OutputNotEmpty(t *testing.T) {
+	f := func(input, output string) bool {
+		return len(output) > 0
+	}
+
+	checkString(t, f)
 }


### PR DESCRIPTION
What
===
Use `testing/quick` for fuzz testing instead of rolling my own solution with `crypto/rand`. Also add two additional fuzz tests.

Why
===
@dgryski @drathier on [twitter](https://twitter.com/drathier/status/958647426474266625) were super helpful to show me that `testing/quick` provides a simple toolset for randomized testing.

They also pointed out that it's use of `math/rand` is more appropriate for tests than `crypto/rand` because it allows me to predictably rerun tests by using the same seed and the use of an explicit generator is preferred so that I'm intentionally generating random inputs that will test my function.